### PR TITLE
Get params from body correctly

### DIFF
--- a/src/Api/Order.php
+++ b/src/Api/Order.php
@@ -174,7 +174,9 @@ class Order extends AbstractEndpoint {
 	public static function update_guest_order( \WP_REST_Request $request, $order ) {
 		do_action( Hooks::GUEST_PRE_UPDATE_ORDER, $request, $order );
 
-		$params = $request->get_body_params();
+		$params = $request->get_body();
+
+		$params = json_decode( $params, true );
 
 		if ( self::validate_address( $params ) ) {
 			return new \WP_Error(


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Bug fix
- **What is the current behavior?** (You can also link to an open issue
  here)
  The parameters in the order were being get from the body_params instead of the body POST object.
- **What is the new behavior (if this is a feature change)?**
  Now the parameters are being got from the body POST objects.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
  No
- **Other information**:
