### PR TITLE
Create a new Filter in the order endpoint in order to be able to modify it by other plugins.

### DIFF
--- a/src/Api/Order.php
+++ b/src/Api/Order.php
@@ -293,7 +293,7 @@ class Order extends AbstractEndpoint {
 			$new_order->calculate_totals();
 			$new_order->total = $new_order->get_total();
 
-			// Add custom values to the filter if needed.
+			// Add custom values to the order if needed.
 			$new_order = apply_filters( Hooks::FORMAT_ORDER_FILTER, $new_order );
 
 			$response[] = $new_order;

--- a/src/Api/Order.php
+++ b/src/Api/Order.php
@@ -289,7 +289,14 @@ class Order extends AbstractEndpoint {
 		$response = [];
 
 		foreach ( $orders as $order ) {
-			$response[] = new \WC_Order( $order->ID );
+			$new_order = new \WC_Order( $order->ID );
+			$new_order->calculate_totals();
+			$new_order->total = $new_order->get_total();
+
+			// Add custom values to the filter if needed.
+			$new_order = apply_filters( Hooks::FORMAT_ORDER_FILTER, $new_order );
+
+			$response[] = $new_order;
 		}
 
 		return $response;

--- a/src/Api/Order.php
+++ b/src/Api/Order.php
@@ -55,7 +55,7 @@ class Order extends AbstractEndpoint {
 			return self::place_order( $request );
 		} else if ( \WP_REST_Server::READABLE === $method ) {
 			// Get all Logged User orders. Returns empty array if the user is not logged in.
-			return self::get_user_orders( $request );
+			return self::format_orders( self::get_user_orders( $request ) );
 		} else {
 			return new \WP_Error(
 				ErrorCodes::METHOD_ERROR,
@@ -277,5 +277,21 @@ class Order extends AbstractEndpoint {
 		}
 
 		return [];
+	}
+
+	/**
+	 * Format orders after getting them.
+	 *
+	 * @param array $orders The orders.
+	 * @return array Orders formatted.
+	 */
+	public static function format_orders( $orders ) {
+		$response = [];
+
+		foreach ( $orders as $order ) {
+			$response[] = new \WC_Order( $order->ID );
+		}
+
+		return $response;
 	}
 }

--- a/src/Utils/Hooks.php
+++ b/src/Utils/Hooks.php
@@ -12,4 +12,6 @@ interface Hooks {
 	const GUEST_AFTER_UPDATE_ORDER = 'ln_wc_after_update_guest_order';
 	const PRE_CHECKOUT = 'ln_wc_pre_checkout';
 	const AFTER_CHECKOUT = 'ln_wc_after_checkout';
+
+	const FORMAT_ORDER_FILTER = 'ln_wc_format_order';
 }


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  New feature
- **What is the current behavior?** (You can also link to an open issue
  here)
  Order endpoint can't be modified by third party plugins
- **What is the new behavior (if this is a feature change)?**
  WIth the new filter, the order can be modified before sending to the API endpoint
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
  No
- **Other information**:
