### PR TITLE
Correctly update meta after object is deleted

### DIFF
--- a/src/Api/Cart.php
+++ b/src/Api/Cart.php
@@ -116,6 +116,8 @@ class Cart extends AbstractEndpoint {
 
 		$cart = self::get_cart( $token_id );
 
+		$cart->remove_cart_item( $product_key );
+
 		if ( $token_id ) {
 			$user = UserController::get_user_by_token( $token_id );
 
@@ -123,8 +125,6 @@ class Cart extends AbstractEndpoint {
 				update_user_meta( $user->ID, self::CART_USER_META, $cart );
 			}
 		}
-
-		$cart->remove_cart_item( $product_key );
 
 		return $cart;
 	}


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Bug fix
- **What is the current behavior?** (You can also link to an open issue
  here)
  The cart is not being correctly saved when the user deletes an item in the mobile app.
- **What is the new behavior (if this is a feature change)?**
  User meta is updated after deleting the item.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
  No
- **Other information**:
