### PR TITLE
Orders need shipping/billing address always

### DIFF
--- a/src/Api/Order.php
+++ b/src/Api/Order.php
@@ -139,19 +139,15 @@ class Order extends AbstractEndpoint {
 
 		$order = new \WC_Order( $order_id );
 
-		// If the user is not logged in, we need to pass the billing and shipping address to the order.
-		// Also is a guest if token_id is false.
-		if ( ! is_user_logged_in() && ! $token_id ) {
-			$order = self::update_guest_order( $request, $order );
+		$order = self::update_guest_order( $request, $order );
 
-			if ( is_wp_error( $order ) ) {
-				// Because we can have errors in $order, delete the order and return the error.
-				if ( in_array( get_post_type( $order_id ), wc_get_order_types(), true ) ) {
-					wp_delete_post( $order_id );
-				}
-
-				return $order;
+		if ( is_wp_error( $order ) ) {
+			// Because we can have errors in $order, delete the order and return the error.
+			if ( in_array( get_post_type( $order_id ), wc_get_order_types(), true ) ) {
+				wp_delete_post( $order_id );
 			}
+
+			return $order;
 		}
 
 		$order->get_total();


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature,
  docs update, ...)
  Behavior change
- **What is the current behavior?** (You can also link to an open issue
  here)
  If the user is logged in , billing/shipping address are not required.
- **What is the new behavior (if this is a feature change)?**
  Billing and shipping address are always required, they should be stored and asked from the BE before the order.
- **Does this PR introduce a breaking change?** (What changes might
  users need to make in their application due to this PR?)
  Users MUST send the shipping/billing address even if they're logged in.
- **Other information**:
