### PR TITLE
Get user orders by user email instead of rely on current user

### DIFF
--- a/src/Api/MultipleCart.php
+++ b/src/Api/MultipleCart.php
@@ -80,22 +80,13 @@ class MultipleCart extends AbstractEndpoint {
 			return $validate;
 		}
 
-		$cart_class = new Cart();
-		$cart = $cart_class::get_cart();
-
-		if ( $token_id ) {
-			$user = UserController::get_user_by_token( $token_id );
-
-			if ( $user ) {
-				$cart = get_user_meta( $user->ID, Cart::CART_USER_META, true );
-			}
-		}
+		$cart = Cart::get_cart( $token_id );
 
 		do_action( Hooks::PRE_MULTIPLE_CART_ITEMS, $cart, $request );
 
 		foreach ( $params as $product ) {
 			$quantity = isset( $product['quantity'] ) ? $product['quantity'] : 1;
-			$cart = $cart_class::add_product_by_id( $cart, $product['product_id'], $quantity );
+			$cart = Cart::add_product_by_id( $cart, $product['product_id'], $quantity );
 		}
 
 		if ( $token_id ) {


### PR DESCRIPTION
The problem was because `is_user_logged_in` it was not working 100% all the
times and the:
- POST
- GET

Endpoints for `create-order` was not working as expected, in this case a change
to use the user email is a more consistent value same as it's working with the
`token_id`.

This change also fix a bug where with any random token we were able to get all
the orders from all the anonymous users.
